### PR TITLE
Add null check of pixels

### DIFF
--- a/Assets/Scripts/Scanner/Scanner.cs
+++ b/Assets/Scripts/Scanner/Scanner.cs
@@ -189,6 +189,10 @@ namespace BarcodeScanner.Scanner
 		{
 			while (Result == null)
 			{
+				if (pixels == null) {
+					pixels = new Color32[0];
+				}
+
 				// Wait
 				if (Status != ScannerStatus.Running || pixels.Length == 00 || Camera.Width == 0)
 				{


### PR DESCRIPTION
NullReferenceException has occurrad in the following point.

Assets/Scripts/Scanner/Scanner.cs 197

```
if (Status != ScannerStatus.Running || pixels.Length == 00 || Camera.Width == 0)
```

pixels might be null at this point.
For this reason there is a possibility that NullReferenceException occurs.

I tried to put null check in the ThreadDecodeQR() method.
## environment

Unity 5.4.1f1
Android Nexus7
Minimum API Level Android 4.4
## Following is using code

```
using UnityEngine;
using System.Collections;
using ZXing;
using BarcodeScanner;
using BarcodeScanner.Scanner;
using BarcodeScanner.Webcam;

public class ReadBarcode : MonoBehaviour
{
    private IScanner barcodeScanner;
    public UnityEngine.UI.Text text;
    public UnityEngine.UI.RawImage image;

    void Start()
    {
        // Create a basic scanner
        this.barcodeScanner = new Scanner();

        // Start playing the camera
        this.barcodeScanner.Camera.Play();

        // Rotation camera direction

        // When for the camera to be ready
        this.barcodeScanner.OnReady += (sender, arg) => {

            // Bind the Camera texture to any RawImage in your scene
            this.image.transform.localEulerAngles = new Vector3(0f, 0f, this.barcodeScanner.Camera.GetRotation());
            this.image.texture = this.barcodeScanner.Camera.Texture;

            // Start Scanning
            this.barcodeScanner.Scan((barCodeType, barCodeValue) => {
                // This callback is call when something is scanned
                this.barcodeScanner.Camera.Stop();
                this.text.text = "Found: " + barCodeType + " / " + barCodeValue;
                Debug.Log("Found: " + barCodeType + " / " + barCodeValue);
            });
        };

    }

    void Update()
    {

        if (this.barcodeScanner == null)
        {
            return;
        }
        // The barcode scanner has to be updated manually
        this.barcodeScanner.Update();
    }
}
```
