### PR TITLE
Fix VideoVerticallyMirrored + Rotation

### DIFF
--- a/Assets/Samples/Boot.cs
+++ b/Assets/Samples/Boot.cs
@@ -12,6 +12,9 @@ public class Boot : MonoBehaviour
 	{
 		Screen.autorotateToPortrait = true;
 		Screen.autorotateToPortraitUpsideDown = true;
+
+		// Enable vsync for the samples (avoid running mobile device at 300fps)
+		QualitySettings.vSyncCount = 1;
 	}
 
 	IEnumerator Start()

--- a/Assets/Samples/Boot.cs
+++ b/Assets/Samples/Boot.cs
@@ -8,7 +8,13 @@ using UnityEngine.SceneManagement;
 /// </summary>
 public class Boot : MonoBehaviour
 {
-	public IEnumerator Start()
+	void Awake()
+	{
+		Screen.autorotateToPortrait = true;
+		Screen.autorotateToPortraitUpsideDown = true;
+	}
+
+	IEnumerator Start()
 	{
 		// When the app start, ask for the authorization to use the webcam
 		yield return Application.RequestUserAuthorization(UserAuthorization.WebCam);

--- a/Assets/Samples/Continuous/ContinuousDemo.cs
+++ b/Assets/Samples/Continuous/ContinuousDemo.cs
@@ -14,6 +14,13 @@ public class ContinuousDemo : MonoBehaviour {
 	public AudioSource Audio;
 	private float RestartTime;
 
+	// Disable Screen Rotation on that screen
+	void Awake()
+	{
+		Screen.autorotateToPortrait = false;
+		Screen.autorotateToPortraitUpsideDown = false;
+	}
+
 	void Start () {
 		// Create a basic scanner
 		BarcodeScanner = new Scanner();
@@ -23,6 +30,7 @@ public class ContinuousDemo : MonoBehaviour {
 		BarcodeScanner.OnReady += (sender, arg) => {
 			// Set Orientation & Texture
 			Image.transform.localEulerAngles = new Vector3(0f, 0f, BarcodeScanner.Camera.GetRotation());
+			Image.transform.localScale = new Vector2(BarcodeScanner.Camera.IsVerticalyMirrored() ? -Image.transform.localScale.x : Image.transform.localScale.x, Image.transform.localScale.y);
 			Image.texture = BarcodeScanner.Camera.Texture;
 			RestartTime = Time.realtimeSinceStartup;
 

--- a/Assets/Samples/Continuous/ContinuousDemo.cs
+++ b/Assets/Samples/Continuous/ContinuousDemo.cs
@@ -30,7 +30,8 @@ public class ContinuousDemo : MonoBehaviour {
 		BarcodeScanner.OnReady += (sender, arg) => {
 			// Set Orientation & Texture
 			Image.transform.localEulerAngles = new Vector3(0f, 0f, BarcodeScanner.Camera.GetRotation());
-			Image.transform.localScale = new Vector2(BarcodeScanner.Camera.IsVerticalyMirrored() ? -Image.transform.localScale.x : Image.transform.localScale.x, Image.transform.localScale.y);
+			float scaleY = BarcodeScanner.Camera.IsVerticalyMirrored() ? -1f : 1f;
+			Image.transform.localScale = new Vector2(Image.transform.localScale.x, scaleY * Image.transform.localScale.y);
 			Image.texture = BarcodeScanner.Camera.Texture;
 			RestartTime = Time.realtimeSinceStartup;
 

--- a/Assets/Samples/Continuous/ContinuousDemo.cs
+++ b/Assets/Samples/Continuous/ContinuousDemo.cs
@@ -29,16 +29,16 @@ public class ContinuousDemo : MonoBehaviour {
 		// Display the camera texture through a RawImage
 		BarcodeScanner.OnReady += (sender, arg) => {
 			// Set Orientation & Texture
-			Image.transform.localEulerAngles = new Vector3(0f, 0f, BarcodeScanner.Camera.GetRotation());
-			float scaleY = BarcodeScanner.Camera.IsVerticalyMirrored() ? -1f : 1f;
-			Image.transform.localScale = new Vector2(Image.transform.localScale.x, scaleY * Image.transform.localScale.y);
+			Image.transform.localEulerAngles = BarcodeScanner.Camera.GetEulerAngles();
+			Image.transform.localScale = BarcodeScanner.Camera.GetScale();
 			Image.texture = BarcodeScanner.Camera.Texture;
-			RestartTime = Time.realtimeSinceStartup;
 
 			// Keep Image Aspect Ratio
 			var rect = Image.GetComponent<RectTransform>();
 			var newHeight = rect.sizeDelta.x * BarcodeScanner.Camera.Height / BarcodeScanner.Camera.Width;
 			rect.sizeDelta = new Vector2(rect.sizeDelta.x, newHeight);
+
+			RestartTime = Time.realtimeSinceStartup;
 		};
 	}
 

--- a/Assets/Samples/Simple/SimpleDemo.cs
+++ b/Assets/Samples/Simple/SimpleDemo.cs
@@ -29,9 +29,8 @@ public class SimpleDemo : MonoBehaviour {
 		// Display the camera texture through a RawImage
 		BarcodeScanner.OnReady += (sender, arg) => {
 			// Set Orientation & Texture
-			Image.transform.localEulerAngles = new Vector3(0f, 0f, BarcodeScanner.Camera.GetRotation());
-			float scaleY = BarcodeScanner.Camera.IsVerticalyMirrored() ? -1f : 1f;
-			Image.transform.localScale = new Vector2(Image.transform.localScale.x, scaleY * Image.transform.localScale.y);
+			Image.transform.localEulerAngles = BarcodeScanner.Camera.GetEulerAngles();
+			Image.transform.localScale = BarcodeScanner.Camera.GetScale();
 			Image.texture = BarcodeScanner.Camera.Texture;
 
 			// Keep Image Aspect Ratio

--- a/Assets/Samples/Simple/SimpleDemo.cs
+++ b/Assets/Samples/Simple/SimpleDemo.cs
@@ -1,11 +1,11 @@
-﻿using UnityEngine;
-using UnityEngine.UI;
-using BarcodeScanner;
+﻿using BarcodeScanner;
 using BarcodeScanner.Scanner;
-using Wizcorp.Utils.Logger;
-using UnityEngine.SceneManagement;
-using System.Collections;
 using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+using Wizcorp.Utils.Logger;
 
 public class SimpleDemo : MonoBehaviour {
 
@@ -13,6 +13,13 @@ public class SimpleDemo : MonoBehaviour {
 	public Text TextHeader;
 	public RawImage Image;
 	public AudioSource Audio;
+
+	// Disable Screen Rotation on that screen
+	void Awake()
+	{
+		Screen.autorotateToPortrait = false;
+		Screen.autorotateToPortraitUpsideDown = false;
+	}
 
 	void Start () {
 		// Create a basic scanner
@@ -23,6 +30,7 @@ public class SimpleDemo : MonoBehaviour {
 		BarcodeScanner.OnReady += (sender, arg) => {
 			// Set Orientation & Texture
 			Image.transform.localEulerAngles = new Vector3(0f, 0f, BarcodeScanner.Camera.GetRotation());
+			Image.transform.localScale = new Vector2(BarcodeScanner.Camera.IsVerticalyMirrored() ? -Image.transform.localScale.x : Image.transform.localScale.x, Image.transform.localScale.y);
 			Image.texture = BarcodeScanner.Camera.Texture;
 
 			// Keep Image Aspect Ratio

--- a/Assets/Samples/Simple/SimpleDemo.cs
+++ b/Assets/Samples/Simple/SimpleDemo.cs
@@ -30,7 +30,8 @@ public class SimpleDemo : MonoBehaviour {
 		BarcodeScanner.OnReady += (sender, arg) => {
 			// Set Orientation & Texture
 			Image.transform.localEulerAngles = new Vector3(0f, 0f, BarcodeScanner.Camera.GetRotation());
-			Image.transform.localScale = new Vector2(BarcodeScanner.Camera.IsVerticalyMirrored() ? -Image.transform.localScale.x : Image.transform.localScale.x, Image.transform.localScale.y);
+			float scaleY = BarcodeScanner.Camera.IsVerticalyMirrored() ? -1f : 1f;
+			Image.transform.localScale = new Vector2(Image.transform.localScale.x, scaleY * Image.transform.localScale.y);
 			Image.texture = BarcodeScanner.Camera.Texture;
 
 			// Keep Image Aspect Ratio

--- a/Assets/Scripts/Interfaces/IWebcam.cs
+++ b/Assets/Scripts/Interfaces/IWebcam.cs
@@ -20,6 +20,7 @@ namespace BarcodeScanner
 		//
 		Color32[] GetPixels();
 		float GetRotation();
+		bool IsVerticalyMirrored();
 		int GetChecksum();
 	}
 }

--- a/Assets/Scripts/Interfaces/IWebcam.cs
+++ b/Assets/Scripts/Interfaces/IWebcam.cs
@@ -21,6 +21,8 @@ namespace BarcodeScanner
 		Color32[] GetPixels();
 		float GetRotation();
 		bool IsVerticalyMirrored();
+		Vector3 GetEulerAngles();
+		Vector3 GetScale();
 		int GetChecksum();
 	}
 }

--- a/Assets/Scripts/README.md
+++ b/Assets/Scripts/README.md
@@ -19,7 +19,7 @@ BarcodeScanner = new Scanner();
 // Start playing the camera
 BarcodeScanner.Camera.Play();
 
-// When for the camera to be ready
+// Event when for the camera is ready to scan
 BarcodeScanner.OnReady += (sender, arg) => {
     
     // Bind the Camera texture to any RawImage in your scene

--- a/Assets/Scripts/Webcam/UnityWebcam.cs
+++ b/Assets/Scripts/Webcam/UnityWebcam.cs
@@ -78,6 +78,16 @@ namespace BarcodeScanner.Webcam
 			return Webcam.videoVerticallyMirrored;
 		}
 
+		public Vector3 GetEulerAngles()
+		{
+			return new Vector3(0f, 0f, GetRotation());
+		}
+
+		public Vector3 GetScale()
+		{
+			return new Vector3(1, IsVerticalyMirrored() ? -1f : 1f, 1);
+		}
+
 		public int GetChecksum()
 		{
 			return (Webcam.width + Webcam.height + Webcam.deviceName + Webcam.videoRotationAngle).GetHashCode();

--- a/Assets/Scripts/Webcam/UnityWebcam.cs
+++ b/Assets/Scripts/Webcam/UnityWebcam.cs
@@ -70,12 +70,12 @@ namespace BarcodeScanner.Webcam
 
 		public float GetRotation()
 		{
-			int rotation = -Webcam.videoRotationAngle;
-			if (Webcam.videoVerticallyMirrored)
-			{
-				rotation += 180;
-			}
-			return rotation;
+			return -Webcam.videoRotationAngle;
+		}
+
+		public bool IsVerticalyMirrored()
+		{
+			return Webcam.videoVerticallyMirrored;
 		}
 
 		public int GetChecksum()

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Since months, I was looking for a good way to parse QRCodes (and generic barcode
 On the Asset Store, few libraries are already providing that, but they are expensive, overly complex, not tested and not always maintained.
 
 So, I was just trying to do something simple, readable, cross-platform and open source.
-* Tested with Unity `5.3.x`, `5.4.x`
-* Tested on `PC`, `Mac`, `Android`, `WebGL`
+* Tested with Unity `5.3.x`, `5.4.x`, `5.5.x`
+* Tested on `PC`, `Mac`, `Android`, `iOS`, `WebGL`
 * Tested with the following barcode format:
   * 1D : `Code 39`, `Code 128`, `ISBN`
   * 2D : `QR Code`, `Aztec`, `Data Matrix`
 
 # How does that work ?
-This project is a Unity Project that you can use directly.
+This project is a Unity Project you can use directly.
 
 Every part is separated and can be replaced or extended if needed
 * Camera : use directly the API of unity to access the webcam (available on iOS, Android, Windows, Mac, Linux, ...)


### PR DESCRIPTION
# Description
Issue found by @dyoxyne
* Fix Vertically Mirror Flag (oops, I misunderstood the flag), now it flips the scale on the y axis and don't do a +180 rotation anymore
* Disable Auto-Rotation on test screen
* Enable the VSync by default on the samples ... the ipad was burning because the demo was running at more than 300fps

More Info: https://docs.unity3d.com/550/Documentation/ScriptReference/WebCamTexture-videoVerticallyMirrored.html

Tested : It fixes the iOS wrong orientation