### PR TITLE
GetPixels() improvement

### DIFF
--- a/Assets/Scripts/Interfaces/IWebcam.cs
+++ b/Assets/Scripts/Interfaces/IWebcam.cs
@@ -18,7 +18,7 @@ namespace BarcodeScanner
 		void Destroy();
 
 		//
-		Color32[] GetPixels();
+		Color32[] GetPixels(Color32[] data);
 		float GetRotation();
 		int GetChecksum();
 	}

--- a/Assets/Scripts/Scanner/Scanner.cs
+++ b/Assets/Scripts/Scanner/Scanner.cs
@@ -124,6 +124,7 @@ namespace BarcodeScanner.Scanner
 				CodeScannerThread.Abort();
 			}
 			#endif
+
 			Callback = null;
 			Status = ScannerStatus.Paused;
 		}

--- a/Assets/Scripts/Settings/ScannerSettings.cs
+++ b/Assets/Scripts/Settings/ScannerSettings.cs
@@ -26,7 +26,7 @@ namespace BarcodeScanner
 		{
 			ScannerBackgroundThread = true;
 			ScannerDelayFrameMin = 3;
-			ScannerDecodeInterval = 0.2f;
+			ScannerDecodeInterval = 0.1f;
 
 			ParserAutoRotate = true;
 			ParserTryInverted = true;

--- a/Assets/Scripts/Webcam/UnityWebcam.cs
+++ b/Assets/Scripts/Webcam/UnityWebcam.cs
@@ -63,9 +63,13 @@ namespace BarcodeScanner.Webcam
 			}
 		}
 
-		public Color32[] GetPixels()
+		public Color32[] GetPixels(Color32[] data = null)
 		{
-			return Webcam.GetPixels32();
+			if (data == null || data.Length != Webcam.width * Webcam.height)
+			{
+				return Webcam.GetPixels32();
+			}
+			return Webcam.GetPixels32(data);
 		}
 
 		public float GetRotation()


### PR DESCRIPTION
# Description
* Implement a new version of IWebcam.GetPixels() to reuse an existing Color32[]

That should avoid extra GC and improve mobile performance.
More Info: https://docs.unity3d.com/ScriptReference/WebCamTexture.GetPixels32.html